### PR TITLE
Add a build-only test workflow, including release/* branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Run java Test
+
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'feature/**'
+      - 'bugfix/**'
+      - 'hotfix/**'
+      - 'release/**'
+
+jobs:
+  Test_application:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests
+        # `build` compiles, builds the sources/javadoc jars and runs the tests — all
+        # of what releases.yml does before publishing, and nothing that publishes.
+        # No signing secret needed: build.gradle skips the Sign tasks when
+        # GPG_SECRET_KEY is unset.
+        run: ./gradlew build


### PR DESCRIPTION
## Pourquoi

Ce repo n'a aucune CI sur `master`, sur les PR, ni sur les branches `release/*`. Le seul workflow qui build est `snapshots.yml`, et il **publie** en même temps.

Ça bloque le garde-fou `05b` de l'outil de release (`lcdp-versioning`), qui refuse de passer le point de non-retour tant que la CI de la branche `release/*` n'est pas verte. Sur ce repo l'outil pousse `master` **et** le tag d'un seul coup, et le tag déclenche directement la publication sur Maven Central : après, c'est publié. Le commit de bump de version que l'outil crée (`version = 'x.y.z'` dans `build.gradle`) n'est relu par personne et n'a jamais vu de CI.

## Ce que fait cette PR

Ajoute `test.yml`, calqué sur le `test.yml` de `lcdp-inventorist-app` (même nom de job `Test_application`, mêmes triggers, `release/**` inclus) :

- `./gradlew build` — compile, construit les jars sources/javadoc et lance les tests : tout ce que `releases.yml` fait avant de publier, et **rien** qui publie.
- Aucun secret nécessaire : `build.gradle` saute les tâches `Sign` quand `GPG_SECRET_KEY` est absent.
- `cache: gradle` pour ne pas retélécharger les dépendances à chaque run.

Volontairement **pas** un ajout de `release/*` aux branches de `snapshots.yml` : sur une branche release la version n'est plus un SNAPSHOT (l'outil a déjà bumpé `build.gradle`), donc `publishToSonatype` pousserait une vraie version en staging sans la fermer — et le `closeAndReleaseSonatypeStagingRepository` du tag tomberait ensuite sur un staging repo déjà ouvert.

## Vérification

`./gradlew build` validé en local sur `master` avec le JDK 21 du workflow : succès.

La branche est nommée `ci/…` et non `feature/…` exprès : `snapshots.yml` écoute `feature/*`, et il aurait tenté de publier la version `1.0.8` déjà présente sur Central.

## Suite

Une fois mergée, l'entrée `offisante-java-sdk` de `projects.yaml` passe à `validate_on_branch: true` côté outil de release (commit déjà prêt).